### PR TITLE
Update install instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ As of now, EaS only supports basic event-information and can convert SquareSpace
 `VEVENT: DTSTART,DTEND,SUMMARY,DESCRIPTION`
 
 ## Installation
-`go get github.com/hawry/events-are-square`
+`go install github.com/hawry/events-are-square@latest`
 or clone this repository.
 ### Dependencies
 Make sure you have all the dependencies installed on your system by changing directory to the source-location of EaS and type:


### PR DESCRIPTION
I tried to install it, but I got the following errors: 
```
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```
```
go: 'go install' requires a version when current directory is not in a module
        Try 'go install github.com/hawry/events-are-square@latest' to install the latest version
```

So I made a small update to the readme.